### PR TITLE
fix(progressive web app): fix gatsby-plugin-manifest config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,8 +16,8 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-manifest',
       options: {
-        name: 'gatsby-starter-default',
-        short_name: 'starter',
+        name: 'React Costa Rica',
+        short_name: 'React Costa Rica',
         start_url: '/',
         background_color: '#663399',
         theme_color: '#663399',


### PR DESCRIPTION
## What's new?

- Fix `gatsby-plugin-manifest-config` adding defaults from Gatsby Default Starter.

## Issue link

- N/A

## URL

- https://fix-manifest-config.d15h0loj9ic2nf.amplifyapp.com/

## Notes

- N/A
