### PR TITLE
chore(github): remove doctoc generated TOC on pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-**Table of Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
-
-- [What's new?](#whats-new)
-- [Issue link](#issue-link)
-- [URL](#url)
-- [Notes](#notes)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 ## What's new?
 
 -


### PR DESCRIPTION
## What's new?

- Remove `doctoc` generated `toc` on Pull Request template

## Issue link

- N/A

## URL

- N/A

## Notes

- N/A
