### PR TITLE
Fix layout min-height

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@emotion/styled": "^10.0.15",
     "emotion-normalize": "^10.1.0",
     "emotion-theming": "^10.0.14",
+    "framer-motion": "^1.6.3",
     "gatsby": "2.13.70",
     "gatsby-image": "^2.2.9",
     "react": "^16.9.0",

--- a/src/components/box.tsx
+++ b/src/components/box.tsx
@@ -5,6 +5,7 @@ type BoxProps = system.BackgroundColorProps &
   system.BorderProps &
   system.FlexboxProps &
   system.LayoutProps &
+  system.OpacityProps &
   system.SpaceProps
 
 export default styled.div<BoxProps>`

--- a/src/hooks/viewport/index.ts
+++ b/src/hooks/viewport/index.ts
@@ -1,29 +1,29 @@
-import { useState, useEffect } from 'react'
+import { useState, useCallback, useMemo, useLayoutEffect } from 'react'
 
 export default function useViewport() {
-  const [viewportSize, setViewportSize] = useState(getViewportSize())
+  const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 })
+  const { width, height } = viewportSize
 
-  const vw = (v: number) => (viewportSize.width * v) / 100
-  const vh = (v: number) => (viewportSize.height * v) / 100
-
-  useEffect(() => {
-    const onResize = () => setViewportSize(getViewportSize())
-    window.addEventListener('resize', onResize)
-
-    return () => {
-      window.removeEventListener('resize', onResize)
-    }
+  const onResize = useCallback(() => {
+    setViewportSize({ width: window.innerWidth, height: window.innerHeight })
   }, [])
 
-  return {
-    vw,
-    vh,
-  }
-}
+  const vw = useCallback((v: number) => (width * v) / 100, [width])
+  const vh = useCallback((v: number) => (height * v) / 100, [height])
 
-function getViewportSize() {
-  return {
-    width: typeof window === 'undefined' ? 0 : window.innerWidth,
-    height: typeof window === 'undefined' ? 0 : window.innerHeight,
-  }
+  useLayoutEffect(() => {
+    onResize()
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [onResize])
+
+  return useMemo(
+    () => ({
+      width,
+      height,
+      vw,
+      vh,
+    }),
+    [height, vh, vw, width]
+  )
 }

--- a/src/hooks/viewport/index.ts
+++ b/src/hooks/viewport/index.ts
@@ -1,0 +1,29 @@
+import { useState, useLayoutEffect } from 'react'
+
+export default function useViewport() {
+  const [viewportSize, setViewportSize] = useState(getViewportSize())
+
+  const vw = (v: number) => (viewportSize.width * v) / 100
+  const vh = (v: number) => (viewportSize.height * v) / 100
+
+  useLayoutEffect(() => {
+    const onResize = () => setViewportSize(getViewportSize())
+    window.addEventListener('resize', onResize)
+
+    return () => {
+      window.removeEventListener('resize', onResize)
+    }
+  }, [])
+
+  return {
+    vw,
+    vh,
+  }
+}
+
+function getViewportSize() {
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }
+}

--- a/src/hooks/viewport/index.ts
+++ b/src/hooks/viewport/index.ts
@@ -23,7 +23,7 @@ export default function useViewport() {
 
 function getViewportSize() {
   return {
-    width: window.innerWidth,
-    height: window.innerHeight,
+    width: typeof window === 'undefined' ? 0 : window.innerWidth,
+    height: typeof window === 'undefined' ? 0 : window.innerHeight,
   }
 }

--- a/src/hooks/viewport/index.ts
+++ b/src/hooks/viewport/index.ts
@@ -1,4 +1,4 @@
-import { useState, useLayoutEffect } from 'react'
+import { useState, useEffect } from 'react'
 
 export default function useViewport() {
   const [viewportSize, setViewportSize] = useState(getViewportSize())
@@ -6,7 +6,7 @@ export default function useViewport() {
   const vw = (v: number) => (viewportSize.width * v) / 100
   const vh = (v: number) => (viewportSize.height * v) / 100
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const onResize = () => setViewportSize(getViewportSize())
     window.addEventListener('resize', onResize)
 

--- a/src/layouts/app/index.tsx
+++ b/src/layouts/app/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { ThemeProvider } from 'emotion-theming'
 import { Global, css } from '@emotion/core'
 import normalize from 'emotion-normalize'
+import { motion } from 'framer-motion'
 
 import useViewport from 'hooks/viewport'
 import theme from 'config/theme'
@@ -16,6 +17,11 @@ export default function AppLayout({ children }: AppLayoutProps) {
   const { vh } = useViewport()
   const viewportHeight = vh(100)
 
+  const variants = {
+    hidden: { opacity: 0, scale: 0.5 },
+    visible: { opacity: 1, scale: 1 },
+  }
+
   return (
     <ThemeProvider theme={theme}>
       <Global
@@ -29,18 +35,24 @@ export default function AppLayout({ children }: AppLayoutProps) {
           }
         `}
       />
-      <Box
-        minHeight={viewportHeight}
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        justifyContent="center"
-        opacity={viewportHeight === 0 ? 0 : 1}
-        p={2}
+
+      <motion.div
+        variants={variants}
+        initial="hidden"
+        animate={!viewportHeight ? 'hidden' : 'visible'}
       >
-        {children}
-        <Footer />
-      </Box>
+        <Box
+          minHeight={viewportHeight}
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          p={2}
+        >
+          {children}
+          <Footer />
+        </Box>
+      </motion.div>
     </ThemeProvider>
   )
 }

--- a/src/layouts/app/index.tsx
+++ b/src/layouts/app/index.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider } from 'emotion-theming'
 import { Global, css } from '@emotion/core'
 import normalize from 'emotion-normalize'
 
+import useViewport from 'hooks/viewport'
 import theme from 'config/theme'
 import Box from 'components/box'
 import Footer from './footer'
@@ -12,6 +13,8 @@ interface AppLayoutProps {
 }
 
 export default function AppLayout({ children }: AppLayoutProps) {
+  const { vh } = useViewport()
+
   return (
     <ThemeProvider theme={theme}>
       <Global
@@ -26,7 +29,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
         `}
       />
       <Box
-        minHeight="100vh"
+        minHeight={vh(100)}
         display="flex"
         flexDirection="column"
         alignItems="center"

--- a/src/layouts/app/index.tsx
+++ b/src/layouts/app/index.tsx
@@ -14,6 +14,7 @@ interface AppLayoutProps {
 
 export default function AppLayout({ children }: AppLayoutProps) {
   const { vh } = useViewport()
+  const viewportHeight = vh(100)
 
   return (
     <ThemeProvider theme={theme}>
@@ -29,11 +30,12 @@ export default function AppLayout({ children }: AppLayoutProps) {
         `}
       />
       <Box
-        minHeight={vh(100)}
+        minHeight={viewportHeight}
         display="flex"
         flexDirection="column"
         alignItems="center"
         justifyContent="center"
+        opacity={viewportHeight === 0 ? 0 : 1}
         p={2}
       >
         {children}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,6 +1283,21 @@
     string-width "^2.0.0"
     strip-ansi "^3"
 
+"@popmotion/easing@^1.0.1", "@popmotion/easing@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"
+  integrity sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==
+
+"@popmotion/popcorn@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@popmotion/popcorn/-/popcorn-0.4.2.tgz#ff9f5334e8e808ed02237b7b9c928619d1eb68ff"
+  integrity sha512-wu0tEwK3KUZ9BoqfcqC3DfdfRDws/oHXwZKJMVtuhXSrF/PtqvilsPjAk93nh8M+orAnbe8ZyxQmop9+4oJs2g==
+  dependencies:
+    "@popmotion/easing" "^1.0.1"
+    framesync "^4.0.1"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.6"
+
 "@reach/router@^1.1.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
@@ -5578,6 +5593,28 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+framer-motion@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-1.6.3.tgz#85307951ca420aceb8edc0852f5bf1e0513f9f77"
+  integrity sha512-1iwnEp/JxrGM+w1AJTIqjnLb35pCqWICaoDyFbkVKXWWKHs+pmSmflp9L+hy+E/1TSX0DKwB/9lYbqG9w7BB7A==
+  dependencies:
+    "@popmotion/easing" "^1.0.2"
+    "@popmotion/popcorn" "^0.4.2"
+    framesync "^4.0.4"
+    hey-listen "^1.0.8"
+    popmotion "9.0.0-beta-8"
+    style-value-types "^3.1.6"
+    stylefire "^6.0.9"
+    tslib "^1.10.0"
+
+framesync@^4.0.0, framesync@^4.0.1, framesync@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-4.0.4.tgz#79c42c0118f26821c078570db0ff81fb863516a2"
+  integrity sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^1.10.0"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -6559,6 +6596,11 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+hey-listen@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
+  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -9670,6 +9712,18 @@ pnp-webpack-plugin@^1.4.1:
   dependencies:
     ts-pnp "^1.1.2"
 
+popmotion@9.0.0-beta-8:
+  version "9.0.0-beta-8"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-beta-8.tgz#f5a709f11737734e84f2a6b73f9bcf25ee30c388"
+  integrity sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==
+  dependencies:
+    "@popmotion/easing" "^1.0.1"
+    "@popmotion/popcorn" "^0.4.2"
+    framesync "^4.0.4"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.6"
+    tslib "^1.10.0"
+
 portfinder@^1.0.21:
   version "1.0.23"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.23.tgz#894db4bcc5daf02b6614517ce89cd21a38226b82"
@@ -11850,6 +11904,13 @@ style-loader@^0.21.0:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
+style-value-types@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.1.6.tgz#6b1da918214d92c74dc7fc2d074013f372b47d76"
+  integrity sha512-AxcfUr/06AHyyyxkNB1O8ypvwa8/qK+sxwelxEN5x+jxW+RXutRE2TuHEQbFq9OBY7ym83CPKvVIsGd6lvKb0Q==
+  dependencies:
+    hey-listen "^1.0.8"
+
 styled-system@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-5.1.0.tgz#52bdb38707e820174146d450fffd64d958365e89"
@@ -11868,6 +11929,16 @@ styled-system@^5.1.0:
     "@styled-system/typography" "^5.1.0"
     "@styled-system/variant" "^5.1.0"
     object-assign "^4.1.1"
+
+stylefire@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-6.0.9.tgz#4c9ab1d2a68e99a2e5a83e11333495824e494632"
+  integrity sha512-HGpTvXAtXbQplESMSvhzFsBtpLNIqMf9hZrdsfoZrJCD0RrF7wyRDc1mhYJym5EL2KQKFAEz+AH6YPOv++VxOQ==
+  dependencies:
+    "@popmotion/popcorn" "^0.4.2"
+    framesync "^4.0.0"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.6"
 
 stylehacks@^4.0.0:
   version "4.0.3"
@@ -12223,7 +12294,7 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
-tslib@^1.6.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.6.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
## What's new?

- Fix layout height on Safari mobile, this is because it was not considering the browser toolbars
- Add a `useViewport` hook to use viewport `width, height` measures and `vw` and `vh` calculations
- Add [`framer-motion`](framer.com/motion) for animating the layout appearance once the window measures are available

## Issue link

- N/A

## URL

- https://fix-layout-min-height.d15h0loj9ic2nf.amplifyapp.com/

## Notes

- Based on [this article](https://css-tricks.com/the-trick-to-viewport-units-on-mobile/)
