### PR TITLE
chore(dependencies): pin eslint to 6.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/styled-system": "^5.1.0",
     "doctoc": "^1.4.0",
     "dotenv": "^8.1.0",
-    "eslint": "^6.2.1",
+    "eslint": "6.2.1",
     "gatsby-plugin-layout": "^1.1.4",
     "gatsby-plugin-manifest": "^2.2.5",
     "gatsby-plugin-material-ui": "^2.1.5",


### PR DESCRIPTION
## What's new?

- Pin ESLint version

## Issue link

- Closes #11

## URL

- https://travis-ci.org/reactcostarica/website/builds/576099478?utm_source=github_status&utm_medium=notification

## Notes

- N/A
