### PR TITLE
chore(dependencies): pin @types/react helmet to 5.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@kevinwolf/eslint-config": "^0.2.3",
-    "@types/react-helmet": "^5.0.9",
+    "@types/react-helmet": "5.0.10",
     "@types/styled-system": "^5.1.0",
     "doctoc": "^1.4.0",
     "dotenv": "^8.1.0",


### PR DESCRIPTION
## What's new?

- Pin `@types/react helmet` version

## Issue link

- Closes #17 

## URL

- https://travis-ci.org/reactcostarica/website/builds/590100717?utm_source=github_status&utm_medium=notification

## Notes

- N/A
